### PR TITLE
Rename tailwind_start.bat to tailwind_start.cmd

### DIFF
--- a/web/tailwind_start.bat
+++ b/web/tailwind_start.bat
@@ -1,1 +1,0 @@
-npx tailwindcss -i ./input.css -o ./public_html/css/main.css --watch --minify

--- a/web/tailwind_start.cmd
+++ b/web/tailwind_start.cmd
@@ -1,0 +1,1 @@
+npx tailwindcss -i ./input.css -o ./public_html/css/main.css --watch --minify


### PR DESCRIPTION
`.bat` extensions use the 16-bit command processor `command.com` where as `.cmd` extensions us the newer 32-bit command processor `cmd.exe` it is recommended to use `cmd.exe` on all NT based systems.