### PR TITLE
Updated pip requirements check to use -U flag

### DIFF
--- a/start_windows.cmd
+++ b/start_windows.cmd
@@ -54,7 +54,7 @@ timeout /t 2
 echo ==========================================
 echo Updating dependencies...
 echo ==========================================
-%python_alias% -m pip install -r requirements.txt >nul 2>nul
+%python_alias% -m pip install -U -r requirements.txt >nul 2>nul
 if %errorlevel% neq 0 (
     echo Failed to update dependencies. Retrying in 5 seconds...
     timeout /t 5


### PR DESCRIPTION
Added the -U flag to pip requirements check in `start_windows.cmd` as currently pip isn't updating the requirements.  The -U flag tells pip to upgrade the package to the latest available version if it's already installed.  If the package is not installed, it will install the latest version.  Also `start_linux.sh` already uses -U flag for requirements check.