### PR TITLE
Update start_linux.sh

### DIFF
--- a/start_linux.sh
+++ b/start_linux.sh
@@ -133,6 +133,8 @@ echo "Press CTRL+C to stop the bot"
 echo "=========================================="
 sleep 3
 
+git config --global init.defaultBranch main
+
 while true; do
     # update the bot
     echo "=========================================="

--- a/start_linux.sh
+++ b/start_linux.sh
@@ -133,7 +133,9 @@ echo "Press CTRL+C to stop the bot"
 echo "=========================================="
 sleep 3
 
-git config --global init.defaultBranch main
+if ! git config --get-regexp init.defaultBranch | grep -q main; then
+    git config --global init.defaultBranch main
+fi
 
 while true; do
     # update the bot


### PR DESCRIPTION
Currently it doesn’t set the default branch to the same branch name as the project, setting the default branch as main wont effect users who have run the command previously and it will only take effect for new users.