### PR TITLE
Update Dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,15 +1,12 @@
-FROM python:3.12.0-slim
+FROM python:3.13.0-slim
 
-LABEL version="1.0"
+LABEL version="1.1"
 LABEL description="MasterCryptoFarmBot Docker Image"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-    
-RUN pip3 install --upgrade pip && \
-    rm -rf /root/.cache/pip/*
 
 RUN echo '#!/bin/bash\n\
 set -e\n\
@@ -46,6 +43,10 @@ RUN useradd -m mcfuser && \
     chown -R mcfuser:mcfuser /MasterCryptoFarmBot
 
 USER mcfuser
+
+RUN pip3 install --upgrade pip && \
+    pip cache purge
+
 WORKDIR /MasterCryptoFarmBot
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Pip currently runs as root which isn’t recommended, moved it to run as the user, changed `rm -rf /root/.cache/pip/*` to `pip cache purge` which is a more elegant way to do the same thing and updated the python version to latest.