### PR TITLE
Reverted python version

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.13.0-slim
+FROM python:3.12.0-slim
 
-LABEL version="1.1"
+LABEL version="1.2"
 LABEL description="MasterCryptoFarmBot Docker Image"
 
 RUN apt-get update && \


### PR DESCRIPTION
Reverted python version back to 3.12 as aiohttp (for wallet_connector) is failing to build on 3.13 https://github.com/aio-libs/aiohttp/issues/8194 https://github.com/aio-libs/aiohttp/issues/8796