### PR TITLE
Update Dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,12 +1,55 @@
-FROM python:3.12.0-slim
+FROM debian:stable-slim
 
-LABEL version="1.2"
+LABEL version="1.3"
 LABEL description="MasterCryptoFarmBot Docker Image"
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    wget \
+    zlib1g-dev \
+    libncurses5-dev \
+    libgdbm-dev \
+    libnss3-dev \
+    libssl-dev \
+    libsqlite3-dev \
+    libreadline-dev \
+    libffi-dev \
+    curl \
+    libbz2-dev \
+    git \
+    ca-certificates \
+    sqlite3 \
+    libsqlite3-dev
+
+RUN wget https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz \
+    && tar -xf Python-3.12.0.tgz \
+    && cd Python-3.12.0 \
+    && ./configure --enable-optimizations --with-ensurepip=install \
+    && make -j $(nproc) \
+    && make altinstall \
+    && cd .. \
+    && rm -rf Python-3.12.0 Python-3.12.0.tgz
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.12 1 \
+    && update-alternatives --set python3 /usr/local/bin/python3.12 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /usr/local/bin/pip3.12 1 \
+    && update-alternatives --set pip3 /usr/local/bin/pip3.12
+
+RUN apt-get purge -y \
+    build-essential \
+    zlib1g-dev \
+    libncurses5-dev \
+    libgdbm-dev \
+    libnss3-dev \
+    libssl-dev \
+    libsqlite3-dev \
+    libreadline-dev \
+    libffi-dev \
+    libbz2-dev \
+    wget \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN echo '#!/bin/bash\n\
 set -e\n\
@@ -44,7 +87,7 @@ RUN useradd -m mcfuser && \
 
 USER mcfuser
 
-RUN pip3 install --upgrade pip && \
+RUN pip3 install --user --upgrade pip && \
     pip3 cache purge
 
 WORKDIR /MasterCryptoFarmBot


### PR DESCRIPTION
[python:3.12-slim](https://hub.docker.com/layers/library/python/3.12-slim/images/sha256-ac212230555ffb7ec17c214fb4cf036ced11b30b5b460994376b0725c7f6c151) has many vulnerabilities as the base OS is very outdated, switched to newest version of Debian but due to this python needs to be built from source to select a specific version, might take a while to build on old devices, tested working.